### PR TITLE
fix(LMS-214): display only possible assignment statuses

### DIFF
--- a/apps/learning/forms.py
+++ b/apps/learning/forms.py
@@ -77,13 +77,11 @@ class AssignmentReviewForm(forms.Form):
     status = forms.ChoiceField(
         label=_("Status"),
         required=True,
-        widget=DisableOptionSelectWidget,
-        choices=AssignmentStatus.choices
+        widget=DisableOptionSelectWidget
     )
     status_old = forms.ChoiceField(
         widget=forms.HiddenInput(),
-        required=True,
-        choices=AssignmentStatus.choices,
+        required=True
     )
 
     def __init__(self, student_assignment: StudentAssignment,
@@ -110,6 +108,10 @@ class AssignmentReviewForm(forms.Form):
         maximum_score = student_assignment.assignment.maximum_score
         self.fields['score'].validators.append(MaxValueValidator(limit_value=maximum_score))
         self.fields['score'].widget.attrs.update({'max': maximum_score})
+        assignment_statuses = [(s.value, s.label)
+                               for s in student_assignment.assignment.statuses]
+        self.fields['status'].choices = assignment_statuses
+        self.fields['status_old'].choices = assignment_statuses
         disabled_statuses = [status for status in AssignmentStatus.values
                              if not student_assignment.is_status_transition_allowed(status)]
         self.fields['status'].widget.disabled_options = disabled_statuses


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code:
    - [x] Good naming: make sure you would understand your code if you read it a few months from now.
    - [x] No common performance issues (e.g. N + 1 problem)
    - [x] Unrelated code has been removed (unused imports, `print` statements, unrelated template context variables, commented code, etc)
    - [x] I have commented my code, particularly in hard-to-understand areas
- [x] I understand that short PRs lead to higher-quality code and faster delivery of features.
- [x] Linear history: my code has been rebased on the most recent commit in the master branch before opening PR
- [x] I have followed [conventional commits specification](https://www.conventionalcommits.org/) for PR title
- [x] I have referenced [YouTrack issue](https://cscenter.myjetbrains.com/youtrack/issue/LMS-214) in the PR description for easy access
- [x] I have added tests that prove my code works
