### PR TITLE
fix: increase timeout for contest API

### DIFF
--- a/apps/grading/tasks.py
+++ b/apps/grading/tasks.py
@@ -96,7 +96,7 @@ def add_new_submission_to_checking_system(submission_id, *, retries):
     files = {'file': ('test.txt', submission_content)}
     try:
         status, json_data = api.add_submission(checker.settings['contest_id'],
-                                               files=files, **data)
+                                               files=files, timeout=5, **data)
     except Unavailable as e:
         if retries:
             scheduler = django_rq.get_scheduler('default')
@@ -158,7 +158,7 @@ def monitor_submission_status_in_yandex_contest(submission_id,
                              monitor_submission_status_in_yandex_contest,
                              submission_id,
                              remote_submission_id,
-                             delay_min=1)
+                             delay_min=1, timeout=5)
         logger.info(f"Remote server is unavailable. "
                     f"Repeat job in 10 minutes.")
         return f"Requeue job in 10 minutes"


### PR DESCRIPTION
# Checklist:

- [ ] I have performed a self-review of my own code:
    - [ ] Good naming: make sure you would understand your code if you read it a few months from now.
    - [ ] No common performance issues (e.g. N + 1 problem)
    - [ ] Unrelated code has been removed (unused imports, `print` statements, unrelated template context variables, commented code, etc)
    - [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I understand that short PRs lead to higher-quality code and faster delivery of features.
- [ ] Linear history: my code has been rebased on the most recent commit in the master branch before opening PR
- [ ] I have followed [conventional commits specification](https://www.conventionalcommits.org/) for PR title
- [ ] I have referenced YouTrack issue in the PR description for easy access
- [ ] I have added tests that prove my code works
