### PR TITLE
refactor: make contest api fail as fast as possible

### DIFF
--- a/apps/grading/api/yandex_contest.py
+++ b/apps/grading/api/yandex_contest.py
@@ -259,24 +259,24 @@ class YandexContestAPI:
     @staticmethod
     def request_and_check(url, method, **kwargs):
         assert method in ('post', 'get')
-        try:
-            response = getattr(requests, method)(url, **kwargs)
-            response.raise_for_status()
-            return response
-        # Some of the network problems
-        except (requests.ConnectionError, requests.Timeout) as e:
-            raise Unavailable() from e
-        # Client 4xx or server 5xx HTTP errors
-        except requests.exceptions.HTTPError as e:
-            response = e.response
-            try:
-                s = response.status_code
-                ResponseStatus(s)  # known statuses
-                raise ContestAPIError(code=s, message=response.text) from e
-            except ValueError:
-                # Unpredictable client or server error
-                logger.exception("Contest API service had internal error.")
-                raise Unavailable() from e
+        # try:
+        response = getattr(requests, method)(url, **kwargs)
+        response.raise_for_status()
+        return response
+        # # Some of the network problems
+        # except (requests.ConnectionError, requests.Timeout) as e:
+        #     raise Unavailable() from e
+        # # Client 4xx or server 5xx HTTP errors
+        # except requests.exceptions.HTTPError as e:
+        #     response = e.response
+        #     try:
+        #         s = response.status_code
+        #         ResponseStatus(s)  # known statuses
+        #         raise ContestAPIError(code=s, message=response.text) from e
+        #     except ValueError:
+        #         # Unpredictable client or server error
+        #         logger.exception("Contest API service had internal error.")
+        #         raise Unavailable() from e
 
     # FIXME: api.contest(42).participant(1).info()
     def participant_info(self, contest_id, participant_id):

--- a/apps/grading/tasks.py
+++ b/apps/grading/tasks.py
@@ -161,7 +161,7 @@ def monitor_submission_status_in_yandex_contest(submission_id,
                              delay_min=1, timeout=5)
         logger.info(f"Remote server is unavailable. "
                     f"Repeat job in 10 minutes.")
-        return f"Requeue job in 10 minutes"
+        return f"Unavailable. Requeue job in 10 minutes. "
     except ContestAPIError as e:
         raise
     # Wait until remote submission check is not finished
@@ -178,7 +178,7 @@ def monitor_submission_status_in_yandex_contest(submission_id,
                              delay_min=delay_min + 1)
         logger.info(f"Submission check {remote_submission_id} is not finished. "
                     f"Rerun in {delay_min} minutes.")
-        return f"Requeue job in {delay_min} minutes"
+        return f"ContestAPIError. Requeue job in {delay_min} minutes"
     # TODO: Investigate how to escape html and store it in json
     # TODO: g.e. look at encoders in simplejson
     json_data.pop("source", None)


### PR DESCRIPTION
# Checklist:

- [ ] I have performed a self-review of my own code:
    - [ ] Good naming: make sure you would understand your code if you read it a few months from now.
    - [ ] No common performance issues (e.g. N + 1 problem)
    - [ ] Unrelated code has been removed (unused imports, `print` statements, unrelated template context variables, commented code, etc)
    - [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I understand that short PRs lead to higher-quality code and faster delivery of features.
- [ ] Linear history: my code has been rebased on the most recent commit in the master branch before opening PR
- [ ] I have followed [conventional commits specification](https://www.conventionalcommits.org/) for PR title
- [ ] I have referenced YouTrack issue in the PR description for easy access
- [ ] I have added tests that prove my code works
