### PR TITLE
feat(LMS-241): add users_id fields to assignment status change log

### DIFF
--- a/apps/learning/teaching/tests/test_views.py
+++ b/apps/learning/teaching/tests/test_views.py
@@ -512,7 +512,15 @@ def test_view_assignment_status_log_csv_online_assignments(client):
                       status=SubmissionStatus.PASSED,
                       meta={'verdict': SubmissionVerdict.WA.value})
 
-    table_headers = ['first_last_name', 'task', 'reviewer', 'action', 'timestamp']
+    table_headers = [
+            "student",
+            "student_id",
+            "task",
+            "comment_author",
+            "comment_author_id",
+            "action",
+            "comment_posted_ISO"
+        ]
     status_log_csv = client.get(csv_download_url).content.decode('utf-8')
     data = [s for s in csv.reader(io.StringIO(status_log_csv)) if s]
     assert data == [table_headers]
@@ -532,8 +540,10 @@ def test_view_assignment_status_log_csv_online_assignments(client):
     data = [s for s in csv.reader(io.StringIO(status_log_csv)) if s]
     expected_created_student1_row = [
         student_two.get_short_name(),
+        str(student_two.pk),
         assignment.title,
         student_two.get_short_name(),
+        str(student_two.pk),
         'решение отправлено на проверку'
     ]
     assert len(data) == 2


### PR DESCRIPTION
# Checklist:

- [ ] I have performed a self-review of my own code:
    - [ ] Good naming: make sure you would understand your code if you read it a few months from now.
    - [ ] No common performance issues (e.g. N + 1 problem)
    - [ ] Unrelated code has been removed (unused imports, `print` statements, unrelated template context variables, commented code, etc)
    - [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I understand that short PRs lead to higher-quality code and faster delivery of features.
- [ ] Linear history: my code has been rebased on the most recent commit in the master branch before opening PR
- [ ] I have followed [conventional commits specification](https://www.conventionalcommits.org/) for PR title
- [ ] I have referenced YouTrack issue in the PR description for easy access
- [ ] I have added tests that prove my code works
