### PR TITLE
Remove internship url

### DIFF
--- a/apps/learning/urls.py
+++ b/apps/learning/urls.py
@@ -26,7 +26,8 @@ urlpatterns = [
 
     path('learning/', include('learning.study.urls')),
     path('learning/useful/', UsefulListView.as_view(), name='learning_useful'),
-    path('learning/internships/', InternshipListView.as_view(), name='learning_internships'),
+    # Commented to return fast in autumn semester
+    # path('learning/internships/', InternshipListView.as_view(), name='learning_internships'),
     path('learning/hc/', HonorCodeView.as_view(), name='honor_code'),
     path('learning/programs/', ProgramsView.as_view(), name='programs'),
     path('learning/library/', include("library.urls")),


### PR DESCRIPTION
Убрал вкладку с инфой стажировок, но забыл убрать ссылку. Сейчас если вбить \learning\internship\ , можно попасть на недоступную вкладку. ПР это исправляет.