### PR TITLE
Replace graduation cap with icon

### DIFF
--- a/lms/jinja2/lms/user_profile/_tab_account.html
+++ b/lms/jinja2/lms/user_profile/_tab_account.html
@@ -12,7 +12,7 @@
                         <i style="font-size:14px" class="fa">&#xf069;</i>
             {% endif %}
             {% if can_view_assignments and enrollment.student_profile.type == StudentTypes.PARTNER %}
-                        <i style="font-size:14px" class="fa">&#127891;</i>
+                        <i class="fa fa-graduation-cap" aria-hidden="true"></i>
             {% endif %}
             <a href="{{ enrollment.course.build_absolute_uri(site=profile_user.site, is_secure=is_secure) }}">
               {{ enrollment.course }} </a>


### PR DESCRIPTION
Было:
![telegram-cloud-photo-size-2-5328118350909397646-m](https://github.com/cscenter/lms/assets/39742182/7da02cea-0eb8-457d-98d3-aff73222ceb4)
Стало:
<img width="75" alt="image" src="https://github.com/cscenter/lms/assets/39742182/2336efb9-d7cd-448d-98ce-e0ec8156b318">

Сделано для однотонности значков в проекте

