### PR TITLE
Temporary disable test_view_application_form_no_campaigns test

### DIFF
--- a/lk_yandexdataschool_ru/apps/application/tests.py
+++ b/lk_yandexdataschool_ru/apps/application/tests.py
@@ -37,6 +37,7 @@ yds_post_data = {
 
 
 @pytest.mark.django_db
+@pytest.mark.skip(reason="Temporary disabled as form with no campaigns needed")
 def test_view_application_form_no_campaigns(client):
     url = reverse('application_form')
     response = client.get(url)


### PR DESCRIPTION
Временно отключаю тест, проверяющий, что форма недоступна при отсутствии кампаний. Потому что сейчас кампаний нет, а форма нужна.
