### PR TITLE
Revert admission view back

### DIFF
--- a/lk_yandexdataschool_ru/apps/application/tests.py
+++ b/lk_yandexdataschool_ru/apps/application/tests.py
@@ -37,7 +37,6 @@ yds_post_data = {
 
 
 @pytest.mark.django_db
-@pytest.mark.skip(reason="Temporary disabled as form with no campaigns needed")
 def test_view_application_form_no_campaigns(client):
     url = reverse('application_form')
     response = client.get(url)

--- a/lk_yandexdataschool_ru/apps/application/views.py
+++ b/lk_yandexdataschool_ru/apps/application/views.py
@@ -53,9 +53,7 @@ class ApplicationFormView(TemplateView):
                 .values('value', 'label', 'campaign_id')
         )
 
-        # show_form must be len(always_allow_campaigns) > 0
-        # Temporary made True for curator purposes
-        show_form = True
+        show_form = len(always_allow_campaigns) > 0
         context["show_form"] = show_form
         utm_params = ["utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"]
         utm = {param: self.request.GET.get(param) for param in utm_params}


### PR DESCRIPTION
Возвращаю назад решение для отображения анкеты при отсутствии активных наборов. Создан тестовый набор. Ссылка осталась _секретной_ 
