### PR TITLE
Profile sort and coloring

### DIFF
--- a/apps/learning/models.py
+++ b/apps/learning/models.py
@@ -555,7 +555,7 @@ class Invitation(TimeStampedModel):
                        kwargs={"token": self.token},
                        subdomain=settings.LMS_SUBDOMAIN)
 
-    @cached_property
+    @property
     def is_active(self):
         today = now_local(self.branch.get_timezone()).date()
         return (EnrollmentPeriod.objects

--- a/apps/learning/tests/test_views.py
+++ b/apps/learning/tests/test_views.py
@@ -156,7 +156,7 @@ def test_course_detail_view_inactive_regular_active_invited_profile_permission(c
     course = course_invitation.course
     invitation = course_invitation.invitation
 
-    student = StudentFactory(student_profile__type=StudentTypes.INVITED)
+    student = StudentFactory(student_profile__type=StudentTypes.INVITED, student_profile__invitation=invitation)
     site = SiteFactory(id=settings.SITE_ID)
     complete_student_profile(student, site, invitation)
     regular_profile = StudentProfileFactory(user=student, year_of_admission=previous_term.year - 1)

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -963,7 +963,12 @@ class StudentProfile(TimeStampedModel):
 
     @property
     def is_invited_active(self):
-        return self.invitation and self.invitation.is_active
+        """
+        Used to check if INVITED StudentProfile has invitation and it is relevant
+        """
+        if self.type != StudentTypes.INVITED:
+            raise ValueError("Works only with invited students. Use is_active for others")
+        return self.invitation is not None and self.invitation.is_active
 
 
 class StudentStatusLog(TimestampedModel):

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -953,7 +953,6 @@ class StudentProfile(TimeStampedModel):
 
     @property
     def is_active(self):
-        # FIXME: make sure profile is not expired for invited student? Should be valid only in the term of invitation
         return not StudentStatuses.is_inactive(self.status)
 
     def get_comment_changed_at_display(self, default=''):
@@ -962,9 +961,9 @@ class StudentProfile(TimeStampedModel):
         return default
 
     @property
-    def is_invited_active(self):
+    def is_invited_student_active(self):
         """
-        Used to check if INVITED StudentProfile has invitation and it is relevant
+        Checks if INVITED StudentProfile has invitation and it is relevant
         """
         if self.type != StudentTypes.INVITED:
             raise ValueError("Works only with invited students. Use is_active for others")

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -961,6 +961,10 @@ class StudentProfile(TimeStampedModel):
             return self.comment_changed_at.strftime(DATETIME_FORMAT_RU)
         return default
 
+    @property
+    def is_invited_active(self):
+        return self.invitation and self.invitation.is_active
+
 
 class StudentStatusLog(TimestampedModel):
     status_changed_at = models.DateField(

--- a/apps/users/services.py
+++ b/apps/users/services.py
@@ -4,6 +4,7 @@ from enum import Enum, auto
 from itertools import islice
 from typing import Any, Dict, List, Optional, Tuple
 
+from django.db.models.functions import Coalesce
 from registration.models import RegistrationProfile
 
 from django.contrib.sites.models import Site
@@ -248,7 +249,7 @@ def get_student_profile(user: User, site, profile_type=None,
     student_profile = (StudentProfile.objects
                        .filter(*filters, user=user, site=site)
                        .select_related('branch')
-                       .order_by('priority', '-year_of_admission', '-pk')
+                       .order_by(Coalesce('year_of_curriculum', 'year_of_admission').desc(), 'priority', '-pk')
                        .first())
     if student_profile is not None:
         # Invalidate cache on user model if the profile has been changed
@@ -265,7 +266,7 @@ def get_student_profiles(*, user: User, site: Site,
     student_profiles = list(StudentProfile.objects
                             .filter(user=user, site=site)
                             .select_related(*select_related)
-                            .order_by('priority', '-year_of_admission', '-pk'))
+                            .order_by(Coalesce('year_of_curriculum', 'year_of_admission').desc(), 'priority', '-pk'))
     syllabus_data = [(sp.year_of_curriculum, sp.branch_id) for sp
                      in student_profiles if sp.year_of_curriculum]
     if syllabus_data:

--- a/apps/users/services.py
+++ b/apps/users/services.py
@@ -199,7 +199,7 @@ def get_student_profile_priority(student_profile: StudentProfile) -> int:
         priority = min_priority + 100
     elif student_profile.status in StudentStatuses.inactive_statuses:
         priority = min_priority + 200
-    if student_profile.type == StudentTypes.INVITED and not student_profile.is_invited_active:
+    if student_profile.type == StudentTypes.INVITED and not student_profile.is_invited_student_active:
         priority = min_priority + 300
     return priority
 

--- a/apps/users/tests/test_models.py
+++ b/apps/users/tests/test_models.py
@@ -200,31 +200,25 @@ def test_student_profile_is_invited_active():
     invitation = InvitationFactory()
     student_profile.invitation = invitation
     assert not student_profile.is_invited_active
-    del invitation.is_active
 
     invitation.semester = Semester.get_current()
     assert not student_profile.is_invited_active
-    del invitation.is_active
 
     today = now_local(invitation.branch.get_timezone()).date()
     enrollmentperiod = EnrollmentPeriodFactory()
     assert not student_profile.is_invited_active
-    del invitation.is_active
 
     enrollmentperiod.semester = Semester.get_current()
     enrollmentperiod.save()
     assert not student_profile.is_invited_active
-    del invitation.is_active
 
     enrollmentperiod.site_id = settings.SITE_ID
     enrollmentperiod.save()
     assert not student_profile.is_invited_active
-    del invitation.is_active
 
     enrollmentperiod.starts_on = today
     enrollmentperiod.save()
     assert not student_profile.is_invited_active
-    del invitation.is_active
 
     enrollmentperiod.ends_on = today
     enrollmentperiod.save()

--- a/apps/users/tests/test_models.py
+++ b/apps/users/tests/test_models.py
@@ -1,14 +1,20 @@
+import datetime
+
 import pytest
 
 from django.core.exceptions import ValidationError
+from django.conf import settings
 
 from core.tests.factories import BranchFactory
 from core.tests.settings import ANOTHER_DOMAIN_ID, TEST_DOMAIN_ID
+from core.timezone import now_local
 from core.utils import instance_memoize
+from courses.models import Semester
 from courses.tests.factories import CourseFactory, SemesterFactory
 from learning.settings import GradeTypes
-from learning.tests.factories import EnrollmentFactory
+from learning.tests.factories import EnrollmentFactory, InvitationFactory, EnrollmentPeriodFactory
 from users.constants import Roles
+from users.models import StudentTypes
 from users.tests.factories import (
     CuratorFactory, StudentFactory, StudentProfileFactory, UserFactory, UserGroupFactory
 )
@@ -180,6 +186,49 @@ def test_student_profile_year_of_admission():
         StudentProfileFactory(branch=branch, year_of_admission=2010)
     student_profile = StudentProfileFactory(branch=branch, year_of_admission=2011)
     assert student_profile.pk
+
+
+@pytest.mark.django_db
+def test_student_profile_is_invited_active():
+    student_profile = StudentProfileFactory()
+    with pytest.raises(ValueError):
+        student_profile.is_invited_active()
+
+    student_profile.type = StudentTypes.INVITED
+    assert not student_profile.is_invited_active
+
+    invitation = InvitationFactory()
+    student_profile.invitation = invitation
+    assert not student_profile.is_invited_active
+    del invitation.is_active
+
+    invitation.semester = Semester.get_current()
+    assert not student_profile.is_invited_active
+    del invitation.is_active
+
+    today = now_local(invitation.branch.get_timezone()).date()
+    enrollmentperiod = EnrollmentPeriodFactory()
+    assert not student_profile.is_invited_active
+    del invitation.is_active
+
+    enrollmentperiod.semester = Semester.get_current()
+    enrollmentperiod.save()
+    assert not student_profile.is_invited_active
+    del invitation.is_active
+
+    enrollmentperiod.site_id = settings.SITE_ID
+    enrollmentperiod.save()
+    assert not student_profile.is_invited_active
+    del invitation.is_active
+
+    enrollmentperiod.starts_on = today
+    enrollmentperiod.save()
+    assert not student_profile.is_invited_active
+    del invitation.is_active
+
+    enrollmentperiod.ends_on = today
+    enrollmentperiod.save()
+    assert student_profile.is_invited_active
 
 
 def test_get_abbreviated_short_name():

--- a/apps/users/tests/test_models.py
+++ b/apps/users/tests/test_models.py
@@ -189,40 +189,40 @@ def test_student_profile_year_of_admission():
 
 
 @pytest.mark.django_db
-def test_student_profile_is_invited_active():
+def test_student_profile_is_invited_student_active():
     student_profile = StudentProfileFactory()
     with pytest.raises(ValueError):
-        student_profile.is_invited_active()
+        student_profile.is_invited_student_active()
 
     student_profile.type = StudentTypes.INVITED
-    assert not student_profile.is_invited_active
+    assert not student_profile.is_invited_student_active
 
     invitation = InvitationFactory()
     student_profile.invitation = invitation
-    assert not student_profile.is_invited_active
+    assert not student_profile.is_invited_student_active
 
     invitation.semester = Semester.get_current()
-    assert not student_profile.is_invited_active
+    assert not student_profile.is_invited_student_active
 
     today = now_local(invitation.branch.get_timezone()).date()
     enrollmentperiod = EnrollmentPeriodFactory()
-    assert not student_profile.is_invited_active
+    assert not student_profile.is_invited_student_active
 
     enrollmentperiod.semester = Semester.get_current()
     enrollmentperiod.save()
-    assert not student_profile.is_invited_active
+    assert not student_profile.is_invited_student_active
 
     enrollmentperiod.site_id = settings.SITE_ID
     enrollmentperiod.save()
-    assert not student_profile.is_invited_active
+    assert not student_profile.is_invited_student_active
 
     enrollmentperiod.starts_on = today
     enrollmentperiod.save()
-    assert not student_profile.is_invited_active
+    assert not student_profile.is_invited_student_active
 
     enrollmentperiod.ends_on = today
     enrollmentperiod.save()
-    assert student_profile.is_invited_active
+    assert student_profile.is_invited_student_active
 
 
 def test_get_abbreviated_short_name():

--- a/lms/jinja2/lms/user_profile/_tab_student_profiles.html
+++ b/lms/jinja2/lms/user_profile/_tab_student_profiles.html
@@ -7,6 +7,10 @@
         {% else %}
           <div class="panel-heading" role="tab" id="headingOne" style="background-color: #add8e6;">
         {% endif %}
+      {% elif student_profile.status == StudentStatuses.ACADEMIC_LEAVE or student_profile.status == StudentStatuses.ACADEMIC_LEAVE_SECOND%}
+        <div class="panel-heading" role="tab" id="headingOne" style="background-color: #fffeca;">
+      {% elif student_profile.status == StudentStatuses.EXPELLED%}
+        <div class="panel-heading" role="tab" id="headingOne" style="background-color: #ffc3bb;">
       {% else %}
         <div class="panel-heading" role="tab" id="headingOne">
       {% endif %}


### PR DESCRIPTION
Задача стояла отделить просроченные приглашенные профили от действующих. Отчислять их нельзя из-за политики доступов. Поэтому добавил отдельную функцию для определения активности для приглашенных студентов. Ее нельзя объединять с уже существующим is_active, потому что тогда по прошествии семестра приглашения отзовутся доступы к прошедшим курсам. Для проверки смотрим актуальность приглашения. У многих старых приглашенных студентов приглашения не было, их тоже относим к неактуальным. Алсу подтвердила, что это не норма и теперь она следит, чтобы у всех приглашения были.
Для отделения старых профилей, в функции определяющей приоритет профиля, такому задаем самый низкий приоритет.
Для отделения этих профилей им был присвоен самый низкий приоритет. После деплоя нужно будет пройтись на проде по всем приглашенным профилям и пересохранить их не изменяя. Потому что приоритет пересчитывается во время сохранения. Скрипт уже есть, проверен локально.
Изменил декоратор функции, которую использовал с cached_property на property. Непонятно зачем было делать так, что активность приглашения рассчитывается всего раз, ибо по окончании семестра действия, очевидно, значение изменится на другое.
Написал тест покрывающий новую функцию, дополнил тест для приоритетов и исправил пару тестов под новые реалии.
Втрой задачей было раскрасить заголовки профилей отчисленных и академщиков в красный и желтый соответственно.