### PR TITLE
Middleware check profile status

### DIFF
--- a/apps/core/middleware.py
+++ b/apps/core/middleware.py
@@ -116,6 +116,6 @@ class UserStatusCheckMiddleware:
 
     def __call__(self, request):
         student_profile = request.user.get_student_profile(settings.SITE_ID)
-        if student_profile and student_profile.status in StudentStatuses.inactive_statuses:
+        if student_profile and StudentStatuses.is_inactive(student_profile.status):
             request.session.pop(SESSION_LOGIN_KEY, None)
         return self.get_response(request)

--- a/apps/core/middleware.py
+++ b/apps/core/middleware.py
@@ -1,5 +1,4 @@
 import logging
-from pyexpat.errors import messages
 
 from django.conf import settings
 from django.http.response import (
@@ -111,7 +110,7 @@ class HealthCheckMiddleware:
 
 class UserStatusCheckMiddleware:
     """
-    Middleware that checks the status of the c in the request.
+    Middleware that checks the status of the client in the request.
     If the student profile is in an inactive status, the session is cleared.
     """
     def __init__(self, get_response):

--- a/apps/core/middleware.py
+++ b/apps/core/middleware.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.http.response import (
     HttpResponse, HttpResponseRedirect, HttpResponseServerError
 )
-from django.urls import reverse
+from core.urls import reverse
 from django.contrib import messages
 
 from apps.learning.settings import StudentStatuses

--- a/apps/core/middleware.py
+++ b/apps/core/middleware.py
@@ -1,14 +1,17 @@
 import logging
+from pyexpat.errors import messages
 
 from django.conf import settings
 from django.http.response import (
     HttpResponse, HttpResponseRedirect, HttpResponseServerError
 )
+from django.urls import reverse
+from django.contrib import messages
 
 from apps.learning.settings import StudentStatuses
-from compscicenter_ru.apps.application.views import SESSION_LOGIN_KEY
 from core.exceptions import Redirect
 from core.models import Branch
+from django.contrib import auth
 
 logger = logging.getLogger(__name__)
 
@@ -117,5 +120,7 @@ class UserStatusCheckMiddleware:
     def __call__(self, request):
         student_profile = request.user.get_student_profile(settings.SITE_ID)
         if student_profile and StudentStatuses.is_inactive(student_profile.status):
-            request.session.pop(SESSION_LOGIN_KEY, None)
+            auth.logout(request)
+            messages.warning(request, "Ваш аккаунт неактивен")
+            return HttpResponseRedirect(redirect_to=reverse('auth:login'))
         return self.get_response(request)

--- a/apps/core/tests/test_middleware.py
+++ b/apps/core/tests/test_middleware.py
@@ -1,6 +1,6 @@
 import pytest
 from apps.learning.settings import StudentStatuses
-from apps.users.tests.factories import StudentFactory
+from apps.users.tests.factories import StudentFactory, UserFactory
 
 
 @pytest.mark.django_db
@@ -10,7 +10,7 @@ from apps.users.tests.factories import StudentFactory
     StudentStatuses.ACADEMIC_LEAVE_SECOND
 ])
 def test_call_with_inactive_student(client, settings, status):
-    student = StudentFactory(email='bounce@simulator.amazonses.com')
+    student = StudentFactory()
     student_profile = student.get_student_profile(settings.SITE_ID)
     student_profile.status = status
     student_profile.save()
@@ -28,7 +28,7 @@ def test_call_with_inactive_student(client, settings, status):
 ])
 def test_call_with_active_student(client, settings, status):
 
-    student = StudentFactory(email='bounce@simulator.amazonses.com')
+    student = StudentFactory()
     student_profile = student.get_student_profile(settings.SITE_ID)
     student_profile.status = status
     student_profile.save()
@@ -39,12 +39,10 @@ def test_call_with_active_student(client, settings, status):
 
 
 @pytest.mark.django_db
-def test_call_without_student_profile(client, mocker):
+def test_call_without_student_profile(client):
 
-    mock_get_student = mocker.patch("users.services.get_student_profile")
-    student = StudentFactory(email='bounce@simulator.amazonses.com')
-    mock_get_student.return_value = None
+    student = UserFactory()
     client.login(student)
 
     response = client.get('/')
-    assert response.status_code
+    assert response.wsgi_request.user.is_authenticated

--- a/apps/core/tests/test_middleware.py
+++ b/apps/core/tests/test_middleware.py
@@ -1,0 +1,65 @@
+import pytest
+from apps.core.middleware import UserStatusCheckMiddleware
+from apps.learning.settings import StudentStatuses
+from apps.users.tests.factories import StudentFactory
+from compscicenter_ru.apps.application.views import SESSION_LOGIN_KEY
+
+@pytest.fixture
+def middleware():
+    return UserStatusCheckMiddleware(get_response=lambda req: 'response')
+
+@pytest.fixture
+def request_with_user():
+    class Request:
+        def __init__(self):
+            self.user = StudentFactory(email='bounce@simulator.amazonses.com')
+            self.session = {}
+    return Request()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("status", [
+    StudentStatuses.EXPELLED,
+    StudentStatuses.ACADEMIC_LEAVE,
+    StudentStatuses.ACADEMIC_LEAVE_SECOND
+])
+def test_call_with_inactive_student(middleware, request_with_user, settings, status):
+
+    request_with_user.session[SESSION_LOGIN_KEY] = 'some_value'
+    student_profile = request_with_user.user.get_student_profile(settings.SITE_ID)
+    student_profile.status = status
+
+    response = middleware(request_with_user)
+
+    assert SESSION_LOGIN_KEY not in request_with_user.session
+    assert response == 'response'
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("status", [
+    StudentStatuses.REINSTATED,
+    StudentStatuses.WILL_GRADUATE,
+    StudentStatuses.GRADUATE
+])
+def test_call_with_active_student(middleware, request_with_user, settings, status):
+
+    request_with_user.session[SESSION_LOGIN_KEY] = 'some_value'
+    student_profile = request_with_user.user.get_student_profile(settings.SITE_ID)
+    student_profile.status = status
+
+    response = middleware(request_with_user)
+
+    assert SESSION_LOGIN_KEY in request_with_user.session
+    assert response == 'response'
+
+
+@pytest.mark.django_db
+def test_call_without_student_profile(middleware, request_with_user, mocker):
+
+    mock_get_student = mocker.patch("users.services.get_student_profile")
+    mock_get_student.return_value = None
+    request_with_user.session[SESSION_LOGIN_KEY] = 'some_value'
+
+    response = middleware(request_with_user)
+
+    assert SESSION_LOGIN_KEY in request_with_user.session
+    assert response == 'response'

--- a/apps/core/tests/test_middleware.py
+++ b/apps/core/tests/test_middleware.py
@@ -1,20 +1,6 @@
 import pytest
-from apps.core.middleware import UserStatusCheckMiddleware
 from apps.learning.settings import StudentStatuses
 from apps.users.tests.factories import StudentFactory
-from compscicenter_ru.apps.application.views import SESSION_LOGIN_KEY
-
-@pytest.fixture
-def middleware():
-    return UserStatusCheckMiddleware(get_response=lambda req: 'response')
-
-@pytest.fixture
-def request_with_user():
-    class Request:
-        def __init__(self):
-            self.user = StudentFactory(email='bounce@simulator.amazonses.com')
-            self.session = {}
-    return Request()
 
 
 @pytest.mark.django_db
@@ -23,16 +9,16 @@ def request_with_user():
     StudentStatuses.ACADEMIC_LEAVE,
     StudentStatuses.ACADEMIC_LEAVE_SECOND
 ])
-def test_call_with_inactive_student(middleware, request_with_user, settings, status):
-
-    request_with_user.session[SESSION_LOGIN_KEY] = 'some_value'
-    student_profile = request_with_user.user.get_student_profile(settings.SITE_ID)
+def test_call_with_inactive_student(client, settings, status):
+    student = StudentFactory(email='bounce@simulator.amazonses.com')
+    student_profile = student.get_student_profile(settings.SITE_ID)
     student_profile.status = status
+    student_profile.save()
+    client.login(student)
 
-    response = middleware(request_with_user)
+    response = client.get('/')
+    assert not response.wsgi_request.user.is_authenticated
 
-    assert SESSION_LOGIN_KEY not in request_with_user.session
-    assert response == 'response'
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("status", [
@@ -40,26 +26,25 @@ def test_call_with_inactive_student(middleware, request_with_user, settings, sta
     StudentStatuses.WILL_GRADUATE,
     StudentStatuses.GRADUATE
 ])
-def test_call_with_active_student(middleware, request_with_user, settings, status):
+def test_call_with_active_student(client, settings, status):
 
-    request_with_user.session[SESSION_LOGIN_KEY] = 'some_value'
-    student_profile = request_with_user.user.get_student_profile(settings.SITE_ID)
+    student = StudentFactory(email='bounce@simulator.amazonses.com')
+    student_profile = student.get_student_profile(settings.SITE_ID)
     student_profile.status = status
+    student_profile.save()
+    client.login(student)
 
-    response = middleware(request_with_user)
-
-    assert SESSION_LOGIN_KEY in request_with_user.session
-    assert response == 'response'
+    response = client.get('/')
+    assert response.wsgi_request.user.is_authenticated
 
 
 @pytest.mark.django_db
-def test_call_without_student_profile(middleware, request_with_user, mocker):
+def test_call_without_student_profile(client, mocker):
 
     mock_get_student = mocker.patch("users.services.get_student_profile")
+    student = StudentFactory(email='bounce@simulator.amazonses.com')
     mock_get_student.return_value = None
-    request_with_user.session[SESSION_LOGIN_KEY] = 'some_value'
+    client.login(student)
 
-    response = middleware(request_with_user)
-
-    assert SESSION_LOGIN_KEY in request_with_user.session
-    assert response == 'response'
+    response = client.get('/')
+    assert response.status_code

--- a/compsciclub_ru/settings/base.py
+++ b/compsciclub_ru/settings/base.py
@@ -48,6 +48,7 @@ MIDDLEWARE = [
     'notifications.middleware.UnreadNotificationsCacheMiddleware',
     'core.middleware.SubdomainBranchMiddleware',
     'core.middleware.RedirectMiddleware',
+    'core.middleware.UserStatusCheckMiddleware',
 ]
 
 INSTALLED_APPS += [

--- a/compsciclub_ru/settings/base.py
+++ b/compsciclub_ru/settings/base.py
@@ -48,7 +48,6 @@ MIDDLEWARE = [
     'notifications.middleware.UnreadNotificationsCacheMiddleware',
     'core.middleware.SubdomainBranchMiddleware',
     'core.middleware.RedirectMiddleware',
-    'core.middleware.UserStatusCheckMiddleware',
 ]
 
 INSTALLED_APPS += [

--- a/lms/settings/base.py
+++ b/lms/settings/base.py
@@ -155,6 +155,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "notifications.middleware.UnreadNotificationsCacheMiddleware",
     "core.middleware.RedirectMiddleware",
+    "core.middleware.UserStatusCheckMiddleware",
 ]
 
 CACHES = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}


### PR DESCRIPTION
[DEVSHAD-221](https://st.yandex-team.ru/DEVSHAD-221)
Fix bug:
If we change student profile status on inactive for student but he hasn't logout he still would be able to see information

# Checklist:


- [x] The **ticket number** is indicated in the comments
- [x] Unrelated code has been removed **(unused imports, `print` statements, unrelated template context variables, commented code, etc)**
- [x] I **translated the new messages** and added only the .po files that actually changed.
- [x] If there were **changes in the frontend**, there is a PR in the front repository.
---
- [x] I have added **tests** that prove my code works
- [ ] No common performance issues **(e.g. N + 1 problem)**


